### PR TITLE
Extend support for deserializing into read-only properties

### DIFF
--- a/src/Dahomey.Json.Tests/ReadOnlyPropertyTests.cs
+++ b/src/Dahomey.Json.Tests/ReadOnlyPropertyTests.cs
@@ -82,7 +82,7 @@ namespace Dahomey.Json.Tests
         }
 
         [Fact]
-        public void TestReadUsingReadOnlyPropertyHandling()
+        public void TestReadUsingReadOnlyPropertyHandlingRead()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.SetupExtensions();
@@ -94,6 +94,21 @@ namespace Dahomey.Json.Tests
             Assert.NotNull(obj);
             Assert.NotNull(obj.MyClass);
             Assert.Equal(12, obj.MyClass.MyInt32);
+        }
+
+        [Fact]
+        public void TestReadUsingReadOnlyPropertyHandlingIgnore()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Ignore);
+
+            const string json = @"{""MyClass"":{""MyInt32"":12}}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyClass>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(default, obj.MyClass.MyInt32);
         }
 
         public class SimpleTestClassWithCollectionUsingJsonDeserialize
@@ -123,7 +138,7 @@ namespace Dahomey.Json.Tests
         }
 
         [Fact]
-        public void TestReadWithCollectionUsingReadOnlyPropertyHandling()
+        public void TestReadWithCollectionUsingReadOnlyPropertyHandlingRead()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.SetupExtensions();
@@ -136,6 +151,21 @@ namespace Dahomey.Json.Tests
             Assert.NotNull(obj.MyClass);
             Assert.Equal(1, obj.MyClass.Count);
             Assert.Equal(12, obj.MyClass[0].MyInt32);
+        }
+
+        [Fact]
+        public void TestReadWithCollectionUsingReadOnlyPropertyHandlingIgnore()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Ignore);
+
+            const string json = @"{""MyClass"":[{""MyInt32"":12}]}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyCollectionProperty>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(0, obj.MyClass.Count);
         }
 
         public class SimpleTestClassWithDictionaryUsingJsonDeserialize
@@ -165,7 +195,7 @@ namespace Dahomey.Json.Tests
         }
 
         [Fact]
-        public void TestReadWithDictionaryUsingReadOnlyPropertyHandling()
+        public void TestReadWithDictionaryUsingReadOnlyPropertyHandlingRead()
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.SetupExtensions();
@@ -179,6 +209,21 @@ namespace Dahomey.Json.Tests
             Assert.Equal(1, obj.MyClass.Count);
             Assert.True(obj.MyClass.ContainsKey("MyKey"));
             Assert.Equal(12, obj.MyClass["MyKey"].MyInt32);
+        }
+
+        [Fact]
+        public void TestReadWithDictionaryUsingReadOnlyPropertyHandlingIgnore()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Ignore);
+
+            const string json = @"{""MyClass"":{""MyKey"":{""MyInt32"":12}}}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyDictionaryProperty>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(0, obj.MyClass.Count);
         }
     }
 }

--- a/src/Dahomey.Json.Tests/ReadOnlyPropertyTests.cs
+++ b/src/Dahomey.Json.Tests/ReadOnlyPropertyTests.cs
@@ -1,5 +1,6 @@
 ﻿using Dahomey.Json.Attributes;
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using Xunit;
 
@@ -73,6 +74,111 @@ namespace Dahomey.Json.Tests
             Assert.NotNull(obj);
             Assert.NotNull(obj.MyClass);
             Assert.Equal(12, obj.MyClass.MyInt32);
+        }
+
+        public class SimpleTestClassWithReadOnlyClass
+        {
+            public SimpleTestClass MyClass { get; } = new SimpleTestClass();
+        }
+
+        [Fact]
+        public void TestReadUsingReadOnlyPropertyHandling()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Read);
+
+            const string json = @"{""MyClass"":{""MyInt32"":12}}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyClass>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(12, obj.MyClass.MyInt32);
+        }
+
+        public class SimpleTestClassWithCollectionUsingJsonDeserialize
+        {
+            [JsonDeserialize]
+            public IList<SimpleTestClass> MyClass { get; } = new List<SimpleTestClass>();
+        }
+
+        [Fact]
+        public void TestReadWithCollectionUsingJsonDeserialize()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+
+            const string json = @"{""MyClass"":[{""MyInt32"":12}]}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithCollectionUsingJsonDeserialize>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(1, obj.MyClass.Count);
+            Assert.Equal(12, obj.MyClass[0].MyInt32);
+        }
+
+        public class SimpleTestClassWithReadOnlyCollectionProperty
+        {
+            public IList<SimpleTestClass> MyClass { get; } = new List<SimpleTestClass>();
+        }
+
+        [Fact]
+        public void TestReadWithCollectionUsingReadOnlyPropertyHandling()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Read);
+
+            const string json = @"{""MyClass"":[{""MyInt32"":12}]}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyCollectionProperty>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(1, obj.MyClass.Count);
+            Assert.Equal(12, obj.MyClass[0].MyInt32);
+        }
+
+        public class SimpleTestClassWithDictionaryUsingJsonDeserialize
+        {
+            [JsonDeserialize]
+            public IDictionary<string, SimpleTestClass> MyClass { get; } = new Dictionary<string, SimpleTestClass>();
+        }
+
+        [Fact]
+        public void TestReadWithDictionaryUsingJsonDeserialize()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+
+            const string json = @"{""MyClass"":{""MyKey"":{""MyInt32"":12}}}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithDictionaryUsingJsonDeserialize>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(1, obj.MyClass.Count);
+            Assert.True(obj.MyClass.ContainsKey("MyKey"));
+            Assert.Equal(12, obj.MyClass["MyKey"].MyInt32);
+        }
+        public class SimpleTestClassWithReadOnlyDictionaryProperty
+        {
+            public IDictionary<string, SimpleTestClass> MyClass { get; } = new Dictionary<string, SimpleTestClass>();
+        }
+
+        [Fact]
+        public void TestReadWithDictionaryUsingReadOnlyPropertyHandling()
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            options.SetReadOnlyPropertyHandling(ReadOnlyPropertyHandling.Read);
+
+            const string json = @"{""MyClass"":{""MyKey"":{""MyInt32"":12}}}";
+            var obj = JsonSerializer.Deserialize<SimpleTestClassWithReadOnlyDictionaryProperty>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.NotNull(obj.MyClass);
+            Assert.Equal(1, obj.MyClass.Count);
+            Assert.True(obj.MyClass.ContainsKey("MyKey"));
+            Assert.Equal(12, obj.MyClass["MyKey"].MyInt32);
         }
     }
 }

--- a/src/Dahomey.Json/JsonSerializerOptionsExtensions.cs
+++ b/src/Dahomey.Json/JsonSerializerOptionsExtensions.cs
@@ -55,6 +55,16 @@ namespace Dahomey.Json
             options.GetState().ReferenceHandling = referenceHandling;
         }
 
+        public static ReadOnlyPropertyHandling GetReadOnlyPropertyHandling(this JsonSerializerOptions options)
+        {
+            return options.GetState().ReadOnlyPropertyHandling;
+        }
+
+        public static void SetReadOnlyPropertyHandling(this JsonSerializerOptions options, ReadOnlyPropertyHandling referenceHandling)
+        {
+            options.GetState().ReadOnlyPropertyHandling = referenceHandling;
+        }
+
         private static JsonSerializerOptionsState GetState(this JsonSerializerOptions options)
         {
             return (JsonSerializerOptionsState)options.GetConverter<JsonSerializerOptionsState>();

--- a/src/Dahomey.Json/JsonSerializerOptionsState.cs
+++ b/src/Dahomey.Json/JsonSerializerOptionsState.cs
@@ -16,6 +16,7 @@ namespace Dahomey.Json
         public DiscriminatorConventionRegistry DiscriminatorConventionRegistry { get; }
         public DictionaryKeyConverterRegistry DictionaryKeyConverterRegistry { get; }
         public ReferenceHandling ReferenceHandling { get; set; }
+        public ReadOnlyPropertyHandling ReadOnlyPropertyHandling { get; set; }
 
         public JsonSerializerOptionsState(JsonSerializerOptions options)
         {

--- a/src/Dahomey.Json/ReadOnlyPropertyHandling.cs
+++ b/src/Dahomey.Json/ReadOnlyPropertyHandling.cs
@@ -1,0 +1,9 @@
+﻿namespace Dahomey.Json
+{
+    public enum ReadOnlyPropertyHandling
+    {
+        Default = 0,
+        Ignore = 1,
+        Read = 2,
+    }
+}

--- a/src/Dahomey.Json/Serialization/Converters/AbstractJsonConverter.cs
+++ b/src/Dahomey.Json/Serialization/Converters/AbstractJsonConverter.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dahomey.Json.Serialization.Converters
+{
+    public abstract class AbstractJsonConverter<T> : JsonConverter<T>
+    {
+        public abstract void Read(ref Utf8JsonReader reader, ref T obj, JsonSerializerOptions options);
+    }
+}

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
@@ -155,7 +155,10 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
             switch (MemberInfo)
             {
                 case PropertyInfo propertyInfo:
-                    CanBeDeserialized = (propertyInfo.CanWrite || propertyInfo.IsDefined(typeof(JsonDeserializeAttribute))) && !propertyInfo.GetMethod.IsStatic;
+                    CanBeDeserialized = (propertyInfo.CanWrite
+                        || _options.GetReadOnlyPropertyHandling() == ReadOnlyPropertyHandling.Read
+                            || (propertyInfo.IsDefined(typeof(JsonDeserializeAttribute)) && _options.GetReadOnlyPropertyHandling() == ReadOnlyPropertyHandling.Default))
+                        && !propertyInfo.GetMethod.IsStatic;
                     break;
 
                 case FieldInfo fieldInfo:

--- a/src/Dahomey.Json/Serialization/Converters/ObjectConverter.cs
+++ b/src/Dahomey.Json/Serialization/Converters/ObjectConverter.cs
@@ -21,7 +21,7 @@ namespace Dahomey.Json.Serialization.Converters
         object CreateInstance();
     }
 
-    public class ObjectConverter<T> : JsonConverter<T>, IObjectConverter
+    public class ObjectConverter<T> : AbstractJsonConverter<T>, IObjectConverter
     {
         private class MemberConverters
         {
@@ -134,7 +134,7 @@ namespace Dahomey.Json.Serialization.Converters
             return obj;
         }
 
-        public void Read(ref Utf8JsonReader reader, ref T obj, JsonSerializerOptions options)
+        public override void Read(ref Utf8JsonReader reader, ref T obj, JsonSerializerOptions options)
         {
             using (new DepthHandler(options))
             {


### PR DESCRIPTION
This commit extends the support for deserializing into read-only properties with the following:
  - Support deserializing into existing collections and dictionaries. Therefore I've created a common base class ```AbstractJsonConverter``` adding the method ```void Read(ref Utf8JsonReader reader, ref T obj, JsonSerializerOptions options)``` and let ```ObjectConverter```, ```AbstractCollectionConverter``` and ```AbstractDictionaryConverter``` inherit from it. The logic for the collection converters have been copied from the object converter already containing it.
  - Add an enum ReadOnlyPropertyHandling in addition to the JsonDeserialize attribute with the values ```Default``` meaning 'use the attribute', ```Ignore``` meaning 'don't serialize into readonly properties' and ```Read``` meaning 'always deserialize into readonly properties'
  - Add check ```_memberSetter == null``` in addition to ```_deserializableReadOnlyProperty``` in MemberConverter