### PR TITLE
Full support for DataMemberAttribute and DataContractAttribute

### DIFF
--- a/src/Dahomey.Json.Tests/DefaultValueTests.cs
+++ b/src/Dahomey.Json.Tests/DefaultValueTests.cs
@@ -62,10 +62,10 @@ namespace Dahomey.Json.Tests
             {
                 objectMapping.AutoMap();
                 objectMapping.ClearMemberMappings();
-                objectMapping.MapMember(o => o.Id).SetDefaultValue(12).SetIngoreIfDefault(true);
-                objectMapping.MapMember(o => o.FirstName).SetDefaultValue("foo").SetIngoreIfDefault(true);
-                objectMapping.MapMember(o => o.LastName).SetDefaultValue("foo").SetIngoreIfDefault(true);
-                objectMapping.MapMember(o => o.Age).SetDefaultValue(12).SetIngoreIfDefault(true);
+                objectMapping.MapMember(o => o.Id).SetDefaultValue(12).SetIgnoreIfDefault(true);
+                objectMapping.MapMember(o => o.FirstName).SetDefaultValue("foo").SetIgnoreIfDefault(true);
+                objectMapping.MapMember(o => o.LastName).SetDefaultValue("foo").SetIgnoreIfDefault(true);
+                objectMapping.MapMember(o => o.Age).SetDefaultValue(12).SetIgnoreIfDefault(true);
             });
 
             ObjectWithDefaultValue2 obj = new ObjectWithDefaultValue2

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -157,7 +157,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
 
             if (memberInfo.IsDefined(typeof(JsonIgnoreIfDefaultAttribute)))
             {
-                memberMapping.SetIngoreIfDefault(true);
+                memberMapping.SetIgnoreIfDefault(true);
             }
         }
 

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/DiscriminatorMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/DiscriminatorMapping.cs
@@ -18,6 +18,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
         public JsonConverter Converter => null;
         public bool CanBeDeserialized => false;
         public bool CanBeSerialized => true;
+        public bool IsHiddenByDataContract => false;
         public object DefaultValue => null;
         public bool IgnoreIfDefault => false;
         public Func<object, bool> ShouldSerializeMethod => null;

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/IMemberMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/IMemberMapping.cs
@@ -13,6 +13,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
         JsonConverter Converter { get; }
         bool CanBeDeserialized { get; }
         bool CanBeSerialized { get; }
+        bool IsHiddenByDataContract { get; }
         object DefaultValue { get; }
         bool IgnoreIfDefault { get; }
         Func<object, bool> ShouldSerializeMethod { get; }

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/IObjectMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/IObjectMapping.cs
@@ -18,6 +18,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
         DiscriminatorPolicy DiscriminatorPolicy { get; }
         object Discriminator { get; }
         IExtensionDataMemberConverter ExtensionData { get; }
+        bool IsDataContract { get; }
 
         void AutoMap();
         bool IsCreatorMember(ReadOnlySpan<byte> memberName);

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
@@ -89,7 +89,9 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
             DataMemberAttribute dataMember = MemberInfo.GetCustomAttribute<DataMemberAttribute>(inherit: false);
             if (dataMember == null)
             {
-                IsHiddenByDataContract = _objectMapping.IsDataContract;
+                IsHiddenByDataContract = _objectMapping.IsDataContract
+                                         && !(MemberInfo.IsDefined(typeof(JsonPropertyAttribute), inherit: false)
+                                             || MemberInfo.IsDefined(typeof(JsonPropertyNameAttribute), inherit: false));
             }
             else
             {

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/MemberMapping.cs
@@ -52,7 +52,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
             return this;
         }
 
-        public MemberMapping<T> SetIngoreIfDefault(bool ignoreIfDefault)
+        public MemberMapping<T> SetIgnoreIfDefault(bool ignoreIfDefault)
         {
             IgnoreIfDefault = ignoreIfDefault;
             return this;

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/ObjectMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/ObjectMapping.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.Serialization;
 using System.Text.Json;
 
 namespace Dahomey.Json.Serialization.Converters.Mappings
@@ -32,6 +33,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
         public DiscriminatorPolicy DiscriminatorPolicy { get; private set; }
         public object Discriminator { get; private set; }
         public IExtensionDataMemberConverter ExtensionData { get; private set; }
+        public bool IsDataContract { get; }
 
         public ObjectMapping(JsonSerializerOptions options)
         {
@@ -42,6 +44,11 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
             {
                 DiscriminatorMapping<T> memberMapping = new DiscriminatorMapping<T>(_options.GetDiscriminatorConventionRegistry(), this);
                 _memberMappings.Add(memberMapping);
+            }
+
+            if (ObjectType.IsDefined(typeof(DataContractAttribute), inherit: false))
+            {
+                IsDataContract = true;
             }
         }
 


### PR DESCRIPTION
* Opt-in serialization like in Newtonsoft.Json ([documentation](https://www.newtonsoft.com/json/help/html/JsonObjectAttributeOptIn.htm))
* If `DataMemberAttribute.IsRequired == true` — then `RequirementPolicy = RequirementPolicy.Always`
* `IgnoreIfDefault = !DataMemberAttribute.EmitDefaultValue`
* `JsonPropertyNameAttribute` has the highest priority and always overwrite the value specified before