### PR TITLE
Support JsonConstructor with memberNames

### DIFF
--- a/src/Dahomey.Json.Tests/CreatorMappingTests.cs
+++ b/src/Dahomey.Json.Tests/CreatorMappingTests.cs
@@ -1,7 +1,7 @@
-﻿using Xunit;
+﻿using Dahomey.Json.Attributes;
 using System;
 using System.Text.Json;
-using Dahomey.Json.Attributes;
+using Xunit;
 
 namespace Dahomey.Json.Tests
 {
@@ -64,6 +64,37 @@ namespace Dahomey.Json.Tests
         [InlineData(@"{""Id"":12}", 12, null, 0)]
         [InlineData(@"{""Id"":12,""Name"":""foo"",""Age"":13}", 12, "foo", 13)]
         public void ConstructorByAttribute(string json, int expectedId, string expectedName, int expectedAge)
+        {
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+
+            ObjectWithConstructor2 obj = Helper.Read<ObjectWithConstructor2>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.Equal(expectedId, obj.Id);
+            Assert.Equal(expectedName, obj.Name);
+            Assert.Equal(expectedAge, obj.Age);
+        }
+
+        private class ObjectWithConstructor3
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public int Age { get; set; }
+
+            [JsonConstructor(nameof(Id), nameof(Name))]
+            public ObjectWithConstructor3(int id, string name)
+            {
+                Id = id;
+                Name = name;
+            }
+        }
+
+        [Theory]
+        [InlineData(@"{""Id"":12,""Name"":""foo""}", 12, "foo", 0)]
+        [InlineData(@"{""Id"":12}", 12, null, 0)]
+        [InlineData(@"{""Id"":12,""Name"":""foo"",""Age"":13}", 12, "foo", 13)]
+        public void ConstructorByAttributeWithMemberNames(string json, int expectedId, string expectedName, int expectedAge)
         {
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.SetupExtensions();

--- a/src/Dahomey.Json.Tests/CreatorMappingTests.cs
+++ b/src/Dahomey.Json.Tests/CreatorMappingTests.cs
@@ -99,7 +99,7 @@ namespace Dahomey.Json.Tests
             JsonSerializerOptions options = new JsonSerializerOptions();
             options.SetupExtensions();
 
-            ObjectWithConstructor2 obj = Helper.Read<ObjectWithConstructor2>(json, options);
+            ObjectWithConstructor3 obj = Helper.Read<ObjectWithConstructor3>(json, options);
 
             Assert.NotNull(obj);
             Assert.Equal(expectedId, obj.Id);

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -112,7 +112,7 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
                 }
                 else
                 {
-                    var memberName = Encoding.UTF8.GetString(_memberNames[i].ToArray());
+                    string memberName = Encoding.UTF8.GetString(_memberNames[i].Span);
                     memberMapping = memberMappings
                         .FirstOrDefault(m => string.Compare(m.MemberName, memberName, ignoreCase: true) == 0);
 

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -112,12 +112,13 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
                 }
                 else
                 {
+                    var memberName = Encoding.UTF8.GetString(_memberNames[i].ToArray());
                     memberMapping = memberMappings
-                        .FirstOrDefault(m => string.Compare(m.MemberName, _memberNames[i].ToString(), ignoreCase: true) == 0);
+                        .FirstOrDefault(m => string.Compare(m.MemberName, memberName, ignoreCase: true) == 0);
 
                     if (memberMapping == null)
                     {
-                        throw new JsonException($"Cannot find a field or property named {_memberNames[i]} on type {_objectMapping.ObjectType.FullName}");
+                        throw new JsonException($"Cannot find a field or property named {memberName} on type {_objectMapping.ObjectType.FullName}");
                     }
                 }
 


### PR DESCRIPTION
Use of ReadOnlyMemory<byte>.ToString() was not correct, since it returns the name of the class. Now correctly converts the actual bytes to string via UTF-8 encoding