### PR TITLE
Fix incorrect .ctor parameter matching when JsonConstructorExAttribute is not present with custom PropertyNamingPolicy

### DIFF
--- a/src/Dahomey.Json.Tests/Dahomey.Json.Tests.csproj
+++ b/src/Dahomey.Json.Tests/Dahomey.Json.Tests.csproj
@@ -6,10 +6,6 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP5_0</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Dahomey.Json.Tests/Dahomey.Json.Tests.csproj
+++ b/src/Dahomey.Json.Tests/Dahomey.Json.Tests.csproj
@@ -6,6 +6,10 @@
     <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP5_0</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/Dahomey.Json.Tests/Issues/Issue0045.cs
+++ b/src/Dahomey.Json.Tests/Issues/Issue0045.cs
@@ -1,6 +1,7 @@
 ﻿using Dahomey.Json.Attributes;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Dahomey.Json.NamingPolicies;
 using Xunit;
 
 namespace Dahomey.Json.Tests.Issues
@@ -10,16 +11,16 @@ namespace Dahomey.Json.Tests.Issues
         public readonly struct MyStruct
         {
 #if NETCOREAPP5_0
-            [JsonConstructorEx("Value")]
+            [JsonConstructorEx("IntValue")]
 #else
-            [JsonConstructor("Value")]
+            [JsonConstructor("IntValue")]
 #endif
-            public MyStruct(int value)
+            public MyStruct(int intValue)
             {
-                Value = value;
+                IntValue = intValue;
             }
 
-            public int Value { get; }
+            public int IntValue { get; }
         }
 
         [Fact]
@@ -30,6 +31,29 @@ namespace Dahomey.Json.Tests.Issues
             options.SetupExtensions();
             var json = JsonSerializer.Serialize(s1, options);
             var s2 = JsonSerializer.Deserialize<MyStruct>(json, options);
+            Assert.Equal(100, s2.IntValue);
+        }
+
+        [Fact]
+        public void TestCamelCase()
+        {
+            var s1 = new MyStruct(100);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+            options.SetupExtensions();
+            var json = JsonSerializer.Serialize(s1, options);
+            var s2 = JsonSerializer.Deserialize<MyStruct>(json, options);
+            Assert.Equal(100, s2.IntValue);
+        }
+
+        [Fact]
+        public void TestSnakeCase()
+        {
+            var s1 = new MyStruct(100);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = new SnakeCaseNamingPolicy() };
+            options.SetupExtensions();
+            var json = JsonSerializer.Serialize(s1, options);
+            var s2 = JsonSerializer.Deserialize<MyStruct>(json, options);
+            Assert.Equal(100, s2.IntValue);
         }
     }
 }

--- a/src/Dahomey.Json.Tests/Issues/Issue0045.cs
+++ b/src/Dahomey.Json.Tests/Issues/Issue0045.cs
@@ -10,7 +10,7 @@ namespace Dahomey.Json.Tests.Issues
     {
         public readonly struct MyStruct
         {
-#if NETCOREAPP5_0
+#if NET5_0
             [JsonConstructorEx("IntValue")]
 #else
             [JsonConstructor("IntValue")]

--- a/src/Dahomey.Json.Tests/Issues/Issue0047.cs
+++ b/src/Dahomey.Json.Tests/Issues/Issue0047.cs
@@ -6,15 +6,10 @@ using Xunit;
 
 namespace Dahomey.Json.Tests.Issues
 {
-    public class Issue0045
+    public class Issue0047
     {
         public readonly struct MyStruct
         {
-#if NETCOREAPP5_0
-            [JsonConstructorEx("IntValue")]
-#else
-            [JsonConstructor("IntValue")]
-#endif
             public MyStruct(int intValue)
             {
                 IntValue = intValue;
@@ -42,8 +37,18 @@ namespace Dahomey.Json.Tests.Issues
             options.SetupExtensions();
             var json = JsonSerializer.Serialize(s1, options);
             var s2 = JsonSerializer.Deserialize<MyStruct>(json, options);
-            // serialized as "intValue", but JsonConstructor specifies "IntValue"
-            Assert.Equal(default, s2.IntValue);
+            Assert.Equal(100, s2.IntValue);
+        }
+
+        [Fact]
+        public void TestSnakeCase()
+        {
+            var s1 = new MyStruct(100);
+            var options = new JsonSerializerOptions { PropertyNamingPolicy = new SnakeCaseNamingPolicy() };
+            options.SetupExtensions();
+            var json = JsonSerializer.Serialize(s1, options);
+            var s2 = JsonSerializer.Deserialize<MyStruct>(json, options);
+            Assert.Equal(100, s2.IntValue);
         }
     }
 }

--- a/src/Dahomey.Json/Attributes/JsonConstructorAttribute.cs
+++ b/src/Dahomey.Json/Attributes/JsonConstructorAttribute.cs
@@ -6,6 +6,7 @@ namespace Dahomey.Json.Attributes
     [AttributeUsage(AttributeTargets.Constructor)]
     public class JsonConstructorExAttribute : Attribute
     {
+        /// <summary>JSON serialized member names of the corresponding parameters of the decorated constructor.</summary>
         public string[]? MemberNames { get; set; }
 
         public JsonConstructorExAttribute()
@@ -21,6 +22,7 @@ namespace Dahomey.Json.Attributes
     [AttributeUsage(AttributeTargets.Constructor)]
     public sealed class JsonConstructorAttribute : Attribute
     {
+        /// <summary>JSON serialized member names of the corresponding parameters of the decorated constructor.</summary>
         public string[]? MemberNames { get; set; }
 
         public JsonConstructorAttribute()

--- a/src/Dahomey.Json/Dahomey.Json.csproj
+++ b/src/Dahomey.Json/Dahomey.Json.csproj
@@ -22,6 +22,10 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP5_0</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />
@@ -34,5 +38,5 @@
   <ItemGroup>
     <None Include="Images\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
-    
+
 </Project>

--- a/src/Dahomey.Json/Dahomey.Json.csproj
+++ b/src/Dahomey.Json/Dahomey.Json.csproj
@@ -22,10 +22,6 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <DefineConstants>$(DefineConstants);NETCOREAPP5_0</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.0" />

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/CreatorMapping.cs
@@ -98,8 +98,10 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
 
                 if (createMemberNames)
                 {
+                    // Infer JSON property names: .ctor parameter --> CLR property (MemberInfo.Name) --> JSON property (MemberName)
+                    // Assumes .ctor parameter name is using the same name as CLR property. They can differ in casing.
                     memberMapping = memberMappings
-                        .FirstOrDefault(m => string.Compare(m.MemberName, parameter.Name, ignoreCase: true) == 0);
+                        .FirstOrDefault(m => string.Compare(m.MemberInfo?.Name ?? m.MemberName, parameter.Name, StringComparison.OrdinalIgnoreCase) == 0);
 
                     if (memberMapping == null || memberMapping.MemberName == null)
                     {
@@ -112,9 +114,10 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
                 }
                 else
                 {
+                    // JsonConstructorExAttribute present: .ctor parameter --> JSON property (Specified in JsonConstructorExAttribute)
                     string memberName = Encoding.UTF8.GetString(_memberNames[i].Span);
                     memberMapping = memberMappings
-                        .FirstOrDefault(m => string.Compare(m.MemberName, memberName, ignoreCase: true) == 0);
+                        .FirstOrDefault(m => string.Compare(m.MemberName, memberName, StringComparison.OrdinalIgnoreCase) == 0);
 
                     if (memberMapping == null)
                     {


### PR DESCRIPTION
Fixes #47 .

Match .ctor parameter name against CLR property name instead of JSON property name when looking for `IMemberMapping` entry.

This applies for the scenario when `[JsonConstructorExAttribute]` is not applied to the type constructor.