### PR TITLE
Update JSON parsing error message logic

### DIFF
--- a/src/Dahomey.Json.Tests/ExceptionTests.cs
+++ b/src/Dahomey.Json.Tests/ExceptionTests.cs
@@ -6,20 +6,28 @@ namespace Dahomey.Json.Tests
 {
     public class ExceptionTests
     {
-        public class Holder
+        public class Inner {
+            [JsonPropertyName("bar")]
+            public long Bar { get; set; }
+        }
+        public class Outer
         {
             [JsonPropertyName("foo")]
-            public long Foo { get; set; }
+            public Inner Foo { get; set; }
         }
 
         [Fact]
         public void TestException()
         {
-            const string json = @"{""foo"": ""a string instead of a number""}";
+            const string innerJson = @"{""bar"": ""a string instead of a number""}";
+            string json = $"{{\"foo\": {innerJson}}}";
 
             JsonSerializerOptions options = new JsonSerializerOptions().SetupExtensions();
-            JsonException exception = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Holder>(json, options));
-            Assert.Equal("The JSON value could not be converted to System.Int64. Path: $.foo", exception.Message);
+            JsonException exception = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Outer>(json, options));
+            Assert.Equal("The JSON value could not be converted at 'foo.bar': Cannot get the value of a token type 'String' as a number.", exception.Message);
+
+            JsonException exception2 = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Inner>(innerJson, options));
+            Assert.Equal("The JSON value could not be converted at 'bar': Cannot get the value of a token type 'String' as a number.", exception2.Message);
         }
     }
 }

--- a/src/Dahomey.Json/MemberJsonExceptionEx.cs
+++ b/src/Dahomey.Json/MemberJsonExceptionEx.cs
@@ -34,7 +34,7 @@ namespace Dahomey.Json
                 }
 
                 var path = String.Join(".", _context);
-                return $"{path}: {inner.Message}";
+                return $"The JSON value could not be converted at '{path}': {inner.Message}";
             }
         }
     }

--- a/src/Dahomey.Json/Serialization/Converters/MemberConverter.cs
+++ b/src/Dahomey.Json/Serialization/Converters/MemberConverter.cs
@@ -33,26 +33,7 @@ namespace Dahomey.Json.Serialization.Converters
         bool ShouldSerialize(ref T instance, Type declaredType, JsonSerializerOptions options);
     }
 
-    public static class ThrowHelper
-    {
-        public static JsonException BuildException(Type memberType, string memberName, Exception innerException)
-        {
-            string path;
-
-            if (innerException is JsonException jsonException)
-            {
-                path = $"{jsonException.Path}.{memberName}";
-            }
-            else
-            {
-                path = $"$.{memberName}";
-            }
-
-            throw new JsonException($"The JSON value could not be converted to {memberType}. Path: {path}", path, null, null, innerException);
-        }
-    }
-
-    public class MemberConverter<T, TM> : IMemberConverter 
+    public class MemberConverter<T, TM> : IMemberConverter
         where T : class
     {
         private readonly Func<T, TM>? _memberGetter;
@@ -138,7 +119,7 @@ namespace Dahomey.Json.Serialization.Converters
                 }
                 catch(Exception ex)
                 {
-                    throw ThrowHelper.BuildException(typeof(TM), MemberNameAsString, ex);
+                    throw new MemberJsonExceptionEx(MemberNameAsString, ex);
                 }
             }
         }
@@ -169,7 +150,7 @@ namespace Dahomey.Json.Serialization.Converters
             }
             catch (Exception ex)
             {
-                throw ThrowHelper.BuildException(typeof(TM), MemberNameAsString, ex);
+                throw new MemberJsonExceptionEx(MemberNameAsString, ex);
             }
         }
 
@@ -331,7 +312,7 @@ namespace Dahomey.Json.Serialization.Converters
             }
             catch (Exception ex)
             {
-                throw ThrowHelper.BuildException(typeof(TM), MemberNameAsString, ex);
+                throw new MemberJsonExceptionEx(MemberNameAsString, ex);
             }
         }
 
@@ -371,7 +352,7 @@ namespace Dahomey.Json.Serialization.Converters
             }
             catch (Exception ex)
             {
-                throw ThrowHelper.BuildException(typeof(TM), MemberNameAsString, ex);
+                throw new MemberJsonExceptionEx(MemberNameAsString, ex);
             }
         }
 


### PR DESCRIPTION
Fixes #54 

In the original fix https://github.com/dahomey-technologies/Dahomey.Json/commit/0a6e834062db6522ab24d740835e5f43cfb0b408, the `MemberJsonExceptionEx` class was introduced but not used. By using it instead of the `ThrowHelper`, the error message matches the new format in the tests.

Please take a look at the test changes (to see the new exception message format) and let me know if I should change anything!

Thanks