### PR TITLE
Also ignore null nullable value when DefaultIgnoreCondition = WhenWritingNull

### DIFF
--- a/src/Dahomey.Json.Tests/JsonIgnoreTests.cs
+++ b/src/Dahomey.Json.Tests/JsonIgnoreTests.cs
@@ -68,6 +68,12 @@ namespace Dahomey.Json.Tests
 
             [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
             public object WhenWritingNull { get; set; }
+
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+            public int? WhenWritingNullableNull { get; set; }
+
+            [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+            public int? WhenWritingNullableValue { get; set; } = 123;
         }
 
         [Fact]
@@ -83,7 +89,7 @@ namespace Dahomey.Json.Tests
                 WhenWritingNull = null,
             };
 
-            const string expected = @"{""Never"":0}";
+            const string expected = @"{""Never"":0,""WhenWritingNullableValue"":123}";
             string actual = JsonSerializer.Serialize(myClass, options);
 
             Assert.Equal(expected, actual);

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -206,7 +206,8 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
             if (jsonIgnoreAttribute != null)
             {
                 if (jsonIgnoreAttribute.Condition == JsonIgnoreCondition.WhenWritingDefault
-                    || jsonIgnoreAttribute.Condition == JsonIgnoreCondition.WhenWritingNull && memberMapping.MemberType.IsClass)
+                    || jsonIgnoreAttribute.Condition == JsonIgnoreCondition.WhenWritingNull 
+                    && (memberMapping.MemberType.IsClass || Nullable.GetUnderlyingType(memberMapping.MemberType) != null))
                 {
                     memberMapping.SetIngoreIfDefault(true);
                 }


### PR DESCRIPTION
Follows up #55 

This PR also ignores the `Nullable<T>` property with null value.