### PR TITLE
Improve error messages when a nested error happens

### DIFF
--- a/src/Dahomey.Json.Tests/ExceptionTests.cs
+++ b/src/Dahomey.Json.Tests/ExceptionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Text.Json;
 using System.Text.Json.Serialization;
+using Dahomey.Json.Attributes;
 using Xunit;
 
 namespace Dahomey.Json.Tests
@@ -8,11 +9,13 @@ namespace Dahomey.Json.Tests
     {
         public class Inner {
             [JsonPropertyName("bar")]
+            [JsonRequired]
             public long Bar { get; set; }
         }
         public class Outer
         {
             [JsonPropertyName("foo")]
+            [JsonRequired]
             public Inner Foo { get; set; }
         }
 
@@ -28,6 +31,19 @@ namespace Dahomey.Json.Tests
 
             JsonException exception2 = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Inner>(innerJson, options));
             Assert.Equal("The JSON value could not be converted to System.Int64. Path: $.bar", exception2.Message);
+
+            json = $"{{\"foo\": {{}}}}";
+            JsonException exception3 = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Outer>(json, options));
+            Assert.Equal("The JSON value could not be converted to Dahomey.Json.Tests.ExceptionTests+Inner due to: Required property 'bar' not found in JSON. Path: $.foo", exception3.Message);
+
+            json = $"{{\"foo\": null}}";
+            JsonException exception4 = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Outer>(json, options));
+            Assert.Equal("Property 'foo' cannot be null.", exception4.Message);
+
+            json = $"{{\"foo\": {{a}}}}";
+            JsonException exception5 = Assert.ThrowsAny<JsonException>(() => JsonSerializer.Deserialize<Outer>(json, options));
+            Assert.StartsWith("The JSON value could not be converted to Dahomey.Json.Tests.ExceptionTests+Inner due to: 'a' is an invalid start of a property name.", exception5.Message);
         }
+
     }
 }

--- a/src/Dahomey.Json/MemberJsonException.cs
+++ b/src/Dahomey.Json/MemberJsonException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Text;
 using System.Text.Json;
 
 namespace Dahomey.Json
@@ -9,7 +10,7 @@ namespace Dahomey.Json
         public Type MemberType { get; }
 
         public MemberJsonException(string memberName, Type memberType, Exception innerException)
-            : base(BuildMessage(memberName, memberType, innerException), 
+            : base(BuildMessage(memberName, memberType, innerException),
                   BuildPath(memberName, innerException), null, null, BuildInnerException(innerException))
         {
             MemberType = BuildMemberType(memberType, innerException);
@@ -29,7 +30,19 @@ namespace Dahomey.Json
 
         private static string BuildMessage(string memberName, Type memberType, Exception innerException)
         {
-            return $"The JSON value could not be converted to {BuildMemberType(memberType, innerException)}. Path: {BuildPath(memberName, innerException)}";
+            var sb = new StringBuilder();
+            var rootMemberType = BuildMemberType(memberType, innerException);
+            sb.Append("The JSON value could not be converted to ");
+            sb.Append(rootMemberType);
+            if (rootMemberType.IsPrimitive) {
+                sb.Append(".");
+            } else {
+                sb.Append(" due to: ");
+                sb.Append(innerException.Message);
+            }
+            sb.Append(" Path: ");
+            sb.Append(BuildPath(memberName, innerException));
+            return sb.ToString();
         }
 
         private static Type BuildMemberType(Type memberType, Exception innerException)


### PR DESCRIPTION
Hi it's me again, the error message guy :joy:

Here's an improvement I propose to the error messages generated. The MemberJsonException stuff is nice, but unfortunately it hides the nested error message in some cases. See the new test; before it would just say `The JSON value could not be converted to Dahomey.Json.Tests.ExceptionTests+Inner. Path: $.foo`, which doesn't tell you which field of foo is causing the problem, or what the problem is

I hope that this is simple enough. It would make a big difference to the project I'm working on. Thanks again for all the work that went into it!