### PR TITLE
feat: adds support for ordering json properties by name

### DIFF
--- a/src/Dahomey.Json.Tests/OrderTests.cs
+++ b/src/Dahomey.Json.Tests/OrderTests.cs
@@ -28,6 +28,20 @@ namespace Dahomey.Json.Tests
             public string FullName { get; set; }
         }
 
+        public class AccountByName
+        {
+            public string EmailAddress { get; set; }
+
+            public bool Deleted { get; set; }
+
+            public DateTime DeletedDate { get; set; }
+
+            public DateTime CreatedDate { get; set; }
+            public DateTime UpdatedDate { get; set; }
+
+            public string FullName { get; set; }
+        }
+
         [Fact]
         public void Order()
         {
@@ -44,6 +58,50 @@ namespace Dahomey.Json.Tests
             JsonSerializerOptions options = new JsonSerializerOptions().SetupExtensions();
 
             const string expected = @"{""FullName"":""Aaron Account"",""EmailAddress"":""aaron@example.com"",""CreatedDate"":""2010-10-01T00:00:00"",""UpdatedDate"":""2013-01-25T00:00:00"",""Deleted"":true,""DeletedDate"":""2013-01-25T00:00:00""}";
+            string actual = JsonSerializer.Serialize(account, options);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OrderByName()
+        {
+            AccountByName account = new()
+            {
+                FullName = "Aaron Account",
+                EmailAddress = "aaron@example.com",
+                Deleted = true,
+                DeletedDate = new DateTime(2013, 1, 25),
+                UpdatedDate = new DateTime(2013, 1, 25),
+                CreatedDate = new DateTime(2010, 10, 1)
+            };
+
+            JsonSerializerOptions options = new JsonSerializerOptions().SetupExtensions();
+            options.SetJsonPropertyOrderByName(true);
+
+            const string expected = @"{""CreatedDate"":""2010-10-01T00:00:00"",""Deleted"":true,""DeletedDate"":""2013-01-25T00:00:00"",""EmailAddress"":""aaron@example.com"",""FullName"":""Aaron Account"",""UpdatedDate"":""2013-01-25T00:00:00""}";
+            string actual = JsonSerializer.Serialize(account, options);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void OrderByNameAndOrder()
+        {
+            Account account = new()
+            {
+                FullName = "Aaron Account",
+                EmailAddress = "aaron@example.com",
+                Deleted = true,
+                DeletedDate = new DateTime(2013, 1, 25),
+                UpdatedDate = new DateTime(2013, 1, 25),
+                CreatedDate = new DateTime(2010, 10, 1)
+            };
+
+            JsonSerializerOptions options = new JsonSerializerOptions().SetupExtensions();
+            options.SetJsonPropertyOrderByName(true);
+
+            const string expected = @"{""FullName"":""Aaron Account"",""CreatedDate"":""2010-10-01T00:00:00"",""Deleted"":true,""DeletedDate"":""2013-01-25T00:00:00"",""EmailAddress"":""aaron@example.com"",""UpdatedDate"":""2013-01-25T00:00:00""}";
             string actual = JsonSerializer.Serialize(account, options);
 
             Assert.Equal(expected, actual);

--- a/src/Dahomey.Json/JsonSerializerOptionsExtensions.cs
+++ b/src/Dahomey.Json/JsonSerializerOptionsExtensions.cs
@@ -90,5 +90,15 @@ namespace Dahomey.Json
         {
             options.GetState().DuplicatePropertyNameHandling = duplicatePropertyNameHandling;
         }
+
+        public static bool GetJsonPropertyOrderByName(this JsonSerializerOptions options)
+        {
+            return options.GetState().JsonPropertyOrderByName;
+        }
+
+        public static void SetJsonPropertyOrderByName(this JsonSerializerOptions options, bool JsonPropertyOrderByName)
+        {
+            options.GetState().JsonPropertyOrderByName = JsonPropertyOrderByName;
+        }
     }
 }

--- a/src/Dahomey.Json/JsonSerializerOptionsState.cs
+++ b/src/Dahomey.Json/JsonSerializerOptionsState.cs
@@ -17,6 +17,7 @@ namespace Dahomey.Json
         public ReadOnlyPropertyHandling ReadOnlyPropertyHandling { get; set; }
         public MissingMemberHandling MissingMemberHandling { get; set; }
         public DuplicatePropertyNameHandling DuplicatePropertyNameHandling { get; set; }
+        public bool JsonPropertyOrderByName { get; set; }
 
         public JsonSerializerOptionsState(JsonSerializerOptions options)
         {

--- a/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
+++ b/src/Dahomey.Json/Serialization/Converters/Mappings/DefaultObjectMappingConvention.cs
@@ -126,7 +126,26 @@ namespace Dahomey.Json.Serialization.Converters.Mappings
                 memberMappings.Add(memberMapping);
             }
 
-            memberMappings.Sort((m1, m2) => m1.Order - m2.Order);
+            if (options.GetJsonPropertyOrderByName())
+            {
+                memberMappings = memberMappings
+                    .OrderBy((m) => m.MemberName ?? m.MemberInfo.Name)
+                    .Select((m, order) =>
+                    {
+                        if (m.Order == 0)
+                        {
+                            m.Order = order;
+                        }
+
+                        return m;
+                    })
+                    .OrderBy((o) => o.Order)
+                    .ToList();
+            }
+            else
+            {
+                memberMappings.Sort((m1, m2) => m1.Order - m2.Order);
+            }
 
             objectMapping.AddMemberMappings(memberMappings);
 


### PR DESCRIPTION
`JsonPropertyOrder` is very useful, if you want to reorder the properties in the output. But it is unpractical it you want the properties to be ordered by name.

This PR adds support for ordering all properties by name, unless `JsonPropertyOrder` override it. I've added two new tests to `OrderTest.cs` to test for both mixing with `JsonPropertyOrder` and only using one of them.

I haven't enabled the feature by default, to avoid changing/breaking the output of old code.

It is enabled with:
```
options.SetJsonPropertyOrderByName(true);
```
