### PR TITLE
#112 - Inheritance with RegisterAssembly depends on class order

### DIFF
--- a/src/Dahomey.Json.Tests/DiscriminatorTests.cs
+++ b/src/Dahomey.Json.Tests/DiscriminatorTests.cs
@@ -262,5 +262,26 @@ namespace Dahomey.Json.Tests
             Assert.Equal("foo", nameObject.Name);
             Assert.Equal(1, nameObject.Id);
         }
+
+        [Fact]
+        public void ReadPolymorphicObjectWithBaseRegister()
+        {
+            const string json = @"{""BaseObject"":{""$type"":12,""Name"":""foo"",""Id"":1}}";
+
+            JsonSerializerOptions options = new JsonSerializerOptions();
+            options.SetupExtensions();
+            DiscriminatorConventionRegistry registry = options.GetDiscriminatorConventionRegistry();
+            registry.ClearConventions();
+            registry.RegisterConvention(new DefaultDiscriminatorConvention<int>(options));
+            registry.RegisterType<BaseObject>();
+            registry.RegisterType<NameObject>();
+
+            BaseObjectHolder obj = JsonSerializer.Deserialize<BaseObjectHolder>(json, options);
+
+            Assert.NotNull(obj);
+            Assert.IsType<NameObject>(obj.BaseObject);
+            Assert.Equal("foo", ((NameObject)obj.BaseObject).Name);
+            Assert.Equal(1, obj.BaseObject.Id);
+        }
     }
 }

--- a/src/Dahomey.Json/Serialization/Conventions/DiscriminatorConventionRegistry.cs
+++ b/src/Dahomey.Json/Serialization/Conventions/DiscriminatorConventionRegistry.cs
@@ -51,7 +51,17 @@ namespace Dahomey.Json.Serialization.Conventions
 
         public IDiscriminatorConvention? GetConvention(Type type)
         {
-            return _conventionsByType.GetOrAdd(type, t => InternalGetConvention(t));
+            if(_conventionsByType.TryGetValue(type, out IDiscriminatorConvention? convention))
+            {
+                return convention;
+            }
+
+            convention = InternalGetConvention(type);
+            if(convention != null)
+            {
+                _conventionsByType.TryAdd(type, convention);
+            }
+            return convention;
         }
 
         public void RegisterAssembly(Assembly assembly)


### PR DESCRIPTION
Fix #112 - Adding type to dictionary only if there is a convention to be used